### PR TITLE
Fixed prop_effect not being selected properly

### DIFF
--- a/lua/weapons/gmod_tool/stools/adv_bone.lua
+++ b/lua/weapons/gmod_tool/stools/adv_bone.lua
@@ -102,6 +102,7 @@ function TOOL:LeftClick( tr )
 	if CLIENT then return true end
 	if ( IsValid( tr.Entity ) ) then
 		local ent = tr.Entity
+		if ( IsValid( ent.AttachedEntity ) ) then ent = ent.AttachedEntity end
 		local physbone = tr.PhysicsBone
 		self:SelectEntity( ent, physbone )
 	end


### PR DESCRIPTION
Trying to select an entity with an AttachedEntity value now selects its AttachedEntity instead. This fixes the tool not working with prop_effect, which doesn't have bones or a proper model itself (it's just an invisible melon prop), but has an attached prop_dynamic with posable bones.