### PR TITLE
Support for sandbox-derived gamemodes

### DIFF
--- a/lua/weapons/gmod_tool/stools/adv_bone.lua
+++ b/lua/weapons/gmod_tool/stools/adv_bone.lua
@@ -71,7 +71,7 @@ if CLIENT then
 
 	local shouldGlow = false
 	hook.Add( "OnContextMenuOpen", "Advanced Bone Tool", function()
-		shouldGlow = ( LocalPlayer():GetTool().Name == "Advanced Bone Tool" )
+		shouldGlow = (LocalPlayer():GetTool()) and (LocalPlayer():GetTool().Name == "Advanced Bone Tool")
 	end )
 
 	hook.Add( "OnContextMenuClose", "Advanced Bone Tool", function()


### PR DESCRIPTION
Just put an extra check for gamemodes that don't always include the toolgun.