### PR TITLE
Small fix to make stuff not reset scale of prop_physics every time they get selected

### DIFF
--- a/lua/weapons/gmod_tool/stools/adv_bone.lua
+++ b/lua/weapons/gmod_tool/stools/adv_bone.lua
@@ -31,6 +31,8 @@ if CLIENT then
 				return
 			end
 
+			if bone == -1 then bone = 0 end -- Apparently prop_physics return -1 as a "physics" bone that causes stuff to reset  every time you select those
+
 			local ang = ent:GetManipulateBoneAngles( bone ) or Angle( 0, 0, 0 )
 			local pos = ent:GetManipulateBonePosition( bone ) or Vector( 0, 0, 0 )
 			local scale = ent:GetManipulateBoneScale( bone ) or Vector( 1, 1, 1 )


### PR DESCRIPTION
Apparently when doing translation of bone to physbone physics prop would return -1 as a bone, and those aren't really the model bones, so it seems to default to the 1 1 1 scale every time.